### PR TITLE
Context revisions

### DIFF
--- a/src/Components/ManifestView/Item/ItemSide/ItemMainImage/test.js
+++ b/src/Components/ManifestView/Item/ItemSide/ItemMainImage/test.js
@@ -3,10 +3,11 @@ import { shallow } from 'enzyme'
 import { Link } from 'react-router-dom'
 import { ItemMainImage } from './'
 import { DEFAULT_ITEM_IMAGE } from 'Configurations/customizations'
+import { ITEM_CONTEXT } from 'Constants/viewingContexts'
 import urlContext from 'Functions/urlContext'
 const match = {
   params: {
-    context: 'item',
+    context: ITEM_CONTEXT,
     contextId: '123',
   },
 }

--- a/src/Components/ManifestView/ManifestDisplayRouter/index.js
+++ b/src/Components/ManifestView/ManifestDisplayRouter/index.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Collection from '../Collection'
+import Item from '../Item'
+import Viewer from '../Viewer'
+import NotFound from 'Components/Shared/NotFound/'
+import {
+  COLLECTION_CONTEXT,
+  ITEM_CONTEXT,
+  VIEWER_CONTEXT,
+} from 'Constants/viewingContexts'
+
+const ManifestDisplayRouter = ({ context, currentManifest }) => {
+  switch (context) {
+    case COLLECTION_CONTEXT:
+      return <Collection currentManifest={currentManifest} />
+    case ITEM_CONTEXT:
+      return <Item currentManifest={currentManifest} />
+    case VIEWER_CONTEXT:
+      return <Viewer currentManifest={currentManifest} />
+    default:
+      return <NotFound />
+  }
+}
+
+ManifestDisplayRouter.propTypes = {
+  context: PropTypes.string.isRequired,
+  currentManifest: PropTypes.shape({
+    status: PropTypes.string.isRequired,
+  }).isRequired,
+}
+
+export default ManifestDisplayRouter

--- a/src/Components/ManifestView/ManifestDisplayRouter/index.js
+++ b/src/Components/ManifestView/ManifestDisplayRouter/index.js
@@ -25,9 +25,7 @@ const ManifestDisplayRouter = ({ context, currentManifest }) => {
 
 ManifestDisplayRouter.propTypes = {
   context: PropTypes.string.isRequired,
-  currentManifest: PropTypes.shape({
-    status: PropTypes.string.isRequired,
-  }).isRequired,
+  currentManifest: PropTypes.object.isRequired,
 }
 
 export default ManifestDisplayRouter

--- a/src/Components/ManifestView/ManifestDisplayRouter/test.js
+++ b/src/Components/ManifestView/ManifestDisplayRouter/test.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import ManifestDisplayRouter from './'
+import Collection from '../Collection'
+import Item from '../Item'
+import Viewer from '../Viewer'
+import NotFound from 'Components/Shared/NotFound/'
+import { STATUS_READY } from 'Store/actions/manifestActions'
+import {
+  COLLECTION_CONTEXT,
+  ITEM_CONTEXT,
+  VIEWER_CONTEXT,
+} from 'Constants/viewingContexts'
+
+const currentManifest = {
+  status: STATUS_READY,
+}
+let wrapper
+
+test('Collection', () => {
+  wrapper = shallow(<ManifestDisplayRouter context={COLLECTION_CONTEXT} currentManifest={currentManifest} />)
+  expect(wrapper.find(Collection).exists()).toBeTruthy()
+})
+
+test('Item', () => {
+  wrapper = shallow(<ManifestDisplayRouter context={ITEM_CONTEXT} currentManifest={currentManifest} />)
+  expect(wrapper.find(Item).exists()).toBeTruthy()
+})
+
+test('Viewer', () => {
+  wrapper = shallow(<ManifestDisplayRouter context={VIEWER_CONTEXT} currentManifest={currentManifest} />)
+  expect(wrapper.find(Viewer).exists()).toBeTruthy()
+})
+
+test('Bad Context', () => {
+  wrapper = shallow(<ManifestDisplayRouter context='badcontext' currentManifest={currentManifest} />)
+  expect(wrapper.find(NotFound).exists()).toBeTruthy()
+})

--- a/src/Components/ManifestView/index.js
+++ b/src/Components/ManifestView/index.js
@@ -2,9 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router'
-import Collection from './Collection'
-import Item from './Item'
-import Viewer from './Viewer'
+import ManifestDisplayRouter from './ManifestDisplayRouter'
+
 import {
   getManifest,
   STATUS_READY,
@@ -20,16 +19,10 @@ export const ManifestView = ({ manifests, match }) => {
   if (currentManifest) {
     switch (currentManifest.status) {
       case STATUS_READY:
-        switch (context) {
-          case 'collection':
-            return <Collection currentManifest={currentManifest} />
-          case 'item':
-            return <Item currentManifest={currentManifest} />
-          case 'viewer':
-            return <Viewer currentManifest={currentManifest} />
-          default:
-            return <NotFound />
-        }
+        return <ManifestDisplayRouter
+          context={context}
+          currentManifest={currentManifest}
+        />
       case STATUS_ERROR:
         return <NotFound />
       default:

--- a/src/Components/ManifestView/test.js
+++ b/src/Components/ManifestView/test.js
@@ -3,21 +3,21 @@ import { shallow } from 'enzyme'
 import { ManifestView } from './'
 import NotFound from 'Components/Shared/NotFound'
 import Loading from 'Components/Shared/Loading'
-import Collection from './Collection'
-import Item from './Item'
-import Viewer from './Viewer'
+import ManifestDisplayRouter from './ManifestDisplayRouter'
 import {
   STATUS_FETCHING,
   STATUS_READY,
   STATUS_ERROR,
 } from 'Store/actions/manifestActions'
-
+import {
+  COLLECTION_CONTEXT,
+} from 'Constants/viewingContexts'
 let wrapper
 
 test('Returns Loading when not ready', () => {
   const match = {
     params: {
-      context: 'collection',
+      context: COLLECTION_CONTEXT,
       contextId: '123',
     },
   }
@@ -31,7 +31,7 @@ test('Returns Loading when not ready', () => {
 test('Returns NotFound when not found', () => {
   const match = {
     params: {
-      context: 'collection',
+      context: COLLECTION_CONTEXT,
       contextId: '456',
     },
   }
@@ -42,10 +42,10 @@ test('Returns NotFound when not found', () => {
   expect(wrapper.find(NotFound).exists()).toBeTruthy()
 })
 
-describe('Returns a view when ready', () => {
+test('Returns ManifestDisplayRouter when ready', () => {
   let match = {
     params: {
-      context: 'collection',
+      context: COLLECTION_CONTEXT,
       contextId: '789',
     },
   }
@@ -53,26 +53,6 @@ describe('Returns a view when ready', () => {
     '789': { status: STATUS_READY },
 
   }
-  test('Collection', () => {
-    wrapper = shallow(<ManifestView match={match} manifests={manifests} />)
-    expect(wrapper.find(Collection).exists()).toBeTruthy()
-  })
-
-  test('Item', () => {
-    match.params.context = 'item'
-    wrapper = shallow(<ManifestView match={match} manifests={manifests} />)
-    expect(wrapper.find(Item).exists()).toBeTruthy()
-  })
-
-  test('Viewer', () => {
-    match.params.context = 'viewer'
-    wrapper = shallow(<ManifestView match={match} manifests={manifests} />)
-    expect(wrapper.find(Viewer).exists()).toBeTruthy()
-  })
-
-  test('Bad Context', () => {
-    match.params.context = 'badcontext'
-    wrapper = shallow(<ManifestView match={match} manifests={manifests} />)
-    expect(wrapper.find(NotFound).exists()).toBeTruthy()
-  })
+  wrapper = shallow(<ManifestView match={match} manifests={manifests} />)
+  expect(wrapper.find(ManifestDisplayRouter).exists()).toBeTruthy()
 })

--- a/src/Constants/viewingContexts.js
+++ b/src/Constants/viewingContexts.js
@@ -1,0 +1,3 @@
+export const ITEM_CONTEXT = 'item'
+export const COLLECTION_CONTEXT = 'collection'
+export const VIEWER_CONTEXT = 'viewer'

--- a/src/Functions/pageUrlFromAtId/index.js
+++ b/src/Functions/pageUrlFromAtId/index.js
@@ -1,9 +1,13 @@
 import { MANIFEST_BASE_URL } from 'Configurations/apis'
+import {
+  COLLECTION_CONTEXT,
+  ITEM_CONTEXT,
+} from 'Constants/viewingContexts'
 
 export default (atId) => {
   if (atId.indexOf('/collection/') > -1) {
-    return `/${atId.replace(`${MANIFEST_BASE_URL}`, '')}`
+    return `/${atId.replace(`${MANIFEST_BASE_URL}`, '').replace('/collection/', `/${COLLECTION_CONTEXT}/`)}`
   } else {
-    return `/item/${atId.replace(`${MANIFEST_BASE_URL}`, '').replace('/manifest', '')}`
+    return `/${ITEM_CONTEXT}/${atId.replace(`${MANIFEST_BASE_URL}`, '').replace('/manifest', '')}`
   }
 }

--- a/src/Functions/pageUrlFromAtId/test.js
+++ b/src/Functions/pageUrlFromAtId/test.js
@@ -1,10 +1,13 @@
 import pageUrlFromAtId from './'
 import { MANIFEST_BASE_URL } from 'Configurations/apis'
-
+import {
+  COLLECTION_CONTEXT,
+  ITEM_CONTEXT,
+} from 'Constants/viewingContexts'
 test('collection in @id url', () => {
-  expect(pageUrlFromAtId(`${MANIFEST_BASE_URL}collection/abc`)).toEqual('/collection/abc')
+  expect(pageUrlFromAtId(`${MANIFEST_BASE_URL}collection/abc`)).toEqual(`/${COLLECTION_CONTEXT}/abc`)
 })
 
 test('collection NOT in @id url', () => {
-  expect(pageUrlFromAtId(`${MANIFEST_BASE_URL}abc/manifest`)).toEqual('/item/abc')
+  expect(pageUrlFromAtId(`${MANIFEST_BASE_URL}abc/manifest`)).toEqual(`/${ITEM_CONTEXT}/abc`)
 })

--- a/src/Store/actions/manifestActions/index.js
+++ b/src/Store/actions/manifestActions/index.js
@@ -1,5 +1,10 @@
 import { MANIFEST_BASE_URL } from 'Configurations/apis.js'
 import fetchJSON from 'Functions/fetchJSON'
+import {
+  COLLECTION_CONTEXT,
+  ITEM_CONTEXT,
+  VIEWER_CONTEXT,
+} from 'Constants/viewingContexts'
 export const FETCH_MANIFEST = 'FETCH_MANIFEST'
 export const RECEIVE_MANIFEST = 'RECEIVE_MANIFEST'
 export const RECEIVE_MANIFEST_ERROR = 'RECEIVE_MANIFEST_ERROR'
@@ -11,9 +16,9 @@ export const getManifest = (context, id) => {
   return dispatch => {
     dispatch(fetchManifest(id))
     let url
-    if (context === 'collection') {
+    if (context === COLLECTION_CONTEXT) {
       url = `${MANIFEST_BASE_URL}collection/${id}`
-    } else if (context === 'item' || context === 'viewer') {
+    } else if (context === ITEM_CONTEXT || context === VIEWER_CONTEXT) {
       url = `${MANIFEST_BASE_URL}${id}/manifest`
     } else {
       return dispatch(manifestError(id, 'invalid context'))

--- a/src/Store/actions/manifestActions/test.js
+++ b/src/Store/actions/manifestActions/test.js
@@ -11,6 +11,10 @@ import {
   manifestError,
 } from 'Store/actions/manifestActions'
 import { MANIFEST_BASE_URL } from 'Configurations/apis.js'
+import {
+  COLLECTION_CONTEXT,
+  ITEM_CONTEXT,
+} from 'Constants/viewingContexts'
 
 const middlewares = [thunk]
 const mockStore = configureMockStore(middlewares)
@@ -38,7 +42,7 @@ test('getManifest for collection', () => {
     { id: '456', type: RECEIVE_MANIFEST, data: { content: ['do something'] } },
   ]
 
-  return store.dispatch(getManifest('collection', '456')).then(() => {
+  return store.dispatch(getManifest(COLLECTION_CONTEXT, '456')).then(() => {
     // return of async actions
     expect(store.getActions()).toEqual(expectedActions)
   })
@@ -54,7 +58,7 @@ test('getManifest for item', () => {
     { id: '654', type: RECEIVE_MANIFEST, data: { content: ['do something'] } },
   ]
 
-  return store.dispatch(getManifest('item', '654')).then(() => {
+  return store.dispatch(getManifest(ITEM_CONTEXT, '654')).then(() => {
     // return of async actions
     expect(store.getActions()).toEqual(expectedActions)
   })
@@ -71,7 +75,7 @@ test('getManifest with error', () => {
     { id: '789', type: RECEIVE_MANIFEST_ERROR },
   ]
 
-  return store.dispatch(getManifest('collection', '789')).then(() => {
+  return store.dispatch(getManifest(COLLECTION_CONTEXT, '789')).then(() => {
     // return of async actions
     expect(store.getActions()).toEqual(expectedActions)
   })


### PR DESCRIPTION
Two revisions to code related to the update url pattern from  MEL-165:

* Moved contexts into name variables so they're easier to find and track.
* Moved a nested switch statement in ManifestDisplay to it's own React component to reduce code complexity: https://codeclimate.com/github/ndlib/mellon-website/issues?category%5B%5D=complexity&status%5B%5D=