### PR TITLE
MEL-286 Fix Alternative image number and when it is displayed

### DIFF
--- a/src/Components/ManifestView/Item/ItemSide/ItemAlternateViews/AlternateImage/AlternateOverlay/index.js
+++ b/src/Components/ManifestView/Item/ItemSide/ItemAlternateViews/AlternateImage/AlternateOverlay/index.js
@@ -2,8 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 const AlternateOverlay = ({ index, max, length }) => {
-  if (max === index + 1) {
-    const overlayNumber = length - index
+  if (max === index + 1 && max !== length) {
+    const overlayNumber = length - max
     return (
       <div className='alternateOverlay'>+{overlayNumber}</div>
     )

--- a/src/Components/ManifestView/Item/ItemSide/ItemAlternateViews/AlternateImage/AlternateOverlay/index.js
+++ b/src/Components/ManifestView/Item/ItemSide/ItemAlternateViews/AlternateImage/AlternateOverlay/index.js
@@ -2,6 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 const AlternateOverlay = ({ index, max, length }) => {
+  // only render on last instance
+  // do not render if total shown equals total available
   if (max === index + 1 && max !== length) {
     const overlayNumber = length - max
     return (

--- a/src/Components/ManifestView/Item/ItemSide/ItemAlternateViews/AlternateImage/AlternateOverlay/test.js
+++ b/src/Components/ManifestView/Item/ItemSide/ItemAlternateViews/AlternateImage/AlternateOverlay/test.js
@@ -10,5 +10,9 @@ test('renders null most of the time', () => {
 test('renders overlay with overlay number', () => {
   const wrapper = shallow(<AlternateOverlay index={1} max={2} length={5} />)
   expect(wrapper.find('.alternateOverlay').exists()).toBeTruthy()
-  expect(wrapper.find('.alternateOverlay').text()).toEqual('+4')
+  expect(wrapper.find('.alternateOverlay').text()).toEqual('+3')
+})
+test('renders null when length === max', () => {
+  const wrapper = shallow(<AlternateOverlay index={0} max={2} length={2} />)
+  expect(wrapper.find('.alternateOveraly').exists()).toBeFalsy()
 })

--- a/src/Components/ManifestView/Item/ItemSide/ItemAlternateViews/AlternateImage/AlternateOverlay/test.js
+++ b/src/Components/ManifestView/Item/ItemSide/ItemAlternateViews/AlternateImage/AlternateOverlay/test.js
@@ -4,7 +4,7 @@ import AlternateOverlay from './'
 
 test('renders null most of the time', () => {
   const wrapper = shallow(<AlternateOverlay index={0} max={2} length={5} />)
-  expect(wrapper.find('.alternateOveraly').exists()).toBeFalsy()
+  expect(wrapper.find('.alternateOverlay').exists()).toBeFalsy()
 })
 
 test('renders overlay with overlay number', () => {
@@ -14,5 +14,5 @@ test('renders overlay with overlay number', () => {
 })
 test('renders null when length === max', () => {
   const wrapper = shallow(<AlternateOverlay index={0} max={2} length={2} />)
-  expect(wrapper.find('.alternateOveraly').exists()).toBeFalsy()
+  expect(wrapper.find('.alternateOverlay').exists()).toBeFalsy()
 })


### PR DESCRIPTION
Ui shows Plus 1 when there are only 4 images on a manifest detail page.

* Fix off by one error in overlay number displayed
* Do not render when max === length
* Update unit tests