### PR TITLE
MEL-291, MEL-292, MEL-308 Accessibility Fixes

### DIFF
--- a/src/Components/App/Page/Footer/index.js
+++ b/src/Components/App/Page/Footer/index.js
@@ -8,7 +8,7 @@ import { links } from 'Configurations/Footer/links'
 import './style.css'
 const Footer = () => {
   return (
-    <div className='Footer'>
+    <footer>
       <div className='footerInner'>
         <div className='footerText'>
           <ReactMarkdown source={footerText} />
@@ -22,7 +22,7 @@ const Footer = () => {
           </nav>
         </div>
       </div>
-    </div>
+    </footer>
   )
 }
 

--- a/src/Components/App/Page/Footer/style.css
+++ b/src/Components/App/Page/Footer/style.css
@@ -1,4 +1,4 @@
-.Footer{
+footer{
   background-color: var(--footer-main-color);
   color: var(--footer-text-color);
   min-height : 64px;
@@ -6,7 +6,7 @@
   bottom: 0;
   left: 0;
 }
-.Footer a {
+footer a {
   color: var(--footer-text-color);
   text-decoration: none;
 }

--- a/src/Components/App/Page/Footer/test.js
+++ b/src/Components/App/Page/Footer/test.js
@@ -5,7 +5,7 @@ import ReactMarkdown from 'react-markdown'
 
 test('Footer renders some divs with markdown text', () => {
   const wrapper = shallow(<Footer />)
-  expect(wrapper.find('.Footer').exists()).toBeTruthy()
+  expect(wrapper.find('footer').exists()).toBeTruthy()
   expect(wrapper.find('.footerInner').exists()).toBeTruthy()
   expect(wrapper.find('.footerText').exists()).toBeTruthy()
   expect(wrapper.find(ReactMarkdown).props().source).toEqual('footerText.md')

--- a/src/Components/App/Page/Header/index.js
+++ b/src/Components/App/Page/Header/index.js
@@ -15,7 +15,7 @@ import HeaderImage from './HeaderImage'
 import './style.css'
 const Header = () => {
   return (
-    <div className='header'>
+    <header className='header'>
       <div className='headerInner'>
         <HeaderImage
           image={INSTITUTION_LOGO}
@@ -33,7 +33,7 @@ const Header = () => {
           linkPath={DEPARTMENT_HOME_PAGE}
         />
       </div>
-    </div>
+    </header>
 
   )
 }

--- a/src/Components/App/Page/NavBar/SiteLogo/index.js
+++ b/src/Components/App/Page/NavBar/SiteLogo/index.js
@@ -10,6 +10,7 @@ const SiteLogo = () => {
   return (
     <div className='siteTitle'>
       <Link to='/'>
+        <h1 className='accessibilityOnly'>Digital Collections</h1>
         <img
           className='siteLogo'
           alt={SITE_LOGO_ALT_TEXT}

--- a/src/Components/App/Page/NavBar/index.js
+++ b/src/Components/App/Page/NavBar/index.js
@@ -7,13 +7,13 @@ import './style.css'
 
 export const NavBar = () => {
   return (
-    <div className='navBar'>
+    <header className='navBar'>
       <div className='navBarInner'>
         <SiteLogo />
         <Hamburger />
         <LoginButton />
       </div>
-    </div>
+    </header>
   )
 }
 

--- a/src/Components/App/Page/index.js
+++ b/src/Components/App/Page/index.js
@@ -38,6 +38,7 @@ Page.propTypes = {
   location: PropTypes.object.isRequired,
 }
 export default withRouter(Page)
+
 // eslint-disable-next-line complexity
 export const getClass = (pathname) => {
   let contentClass

--- a/src/Components/App/Page/index.js
+++ b/src/Components/App/Page/index.js
@@ -11,6 +11,7 @@ export const Page = ({ children, location }) => {
 
   return (
     <React.Fragment>
+      <a className='skipToMain' href='#main'>Skip to main content</a>
       <Header />
       <NavBar />
       <div className={contentClass}>

--- a/src/Components/App/Page/index.js
+++ b/src/Components/App/Page/index.js
@@ -5,9 +5,17 @@ import './style.css'
 import Header from './Header'
 import NavBar from './NavBar'
 import Footer from './Footer'
+import {
+  BROWSE_CONTEXT,
+  COLLECTION_CONTEXT,
+  ITEM_CONTEXT,
+  VIEWER_CONTEXT,
+  EXHIBITIONS_CONTEXT,
+  SEARCH_CONTEXT,
+} from 'Constants/viewingContexts'
 
 export const Page = ({ children, location }) => {
-  const contentClass = location.pathname === '/' ? 'home mainContent' : 'mainContent'
+  const contentClass = getClass(location.pathname)
 
   return (
     <React.Fragment>
@@ -30,3 +38,25 @@ Page.propTypes = {
   location: PropTypes.object.isRequired,
 }
 export default withRouter(Page)
+// eslint-disable-next-line complexity
+export const getClass = (pathname) => {
+  let contentClass
+  if (pathname === '/') {
+    contentClass = 'home mainContent'
+  } else if (pathname.indexOf(BROWSE_CONTEXT) === 1) {
+    contentClass = 'browse mainContent'
+  } else if (pathname.indexOf(COLLECTION_CONTEXT) === 1) {
+    contentClass = 'collection mainContent'
+  } else if (pathname.indexOf(ITEM_CONTEXT) === 1) {
+    contentClass = 'item mainContent'
+  } else if (pathname.indexOf(VIEWER_CONTEXT) === 1) {
+    contentClass = 'viewer mainContent'
+  } else if (pathname.indexOf(EXHIBITIONS_CONTEXT) === 1) {
+    contentClass = 'exhibitions mainContent'
+  } else if (pathname.indexOf(SEARCH_CONTEXT) === 1) {
+    contentClass = 'search mainContent'
+  } else {
+    contentClass = 'mainContent'
+  }
+  return contentClass
+}

--- a/src/Components/App/Page/index.js
+++ b/src/Components/App/Page/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { PropTypes } from 'prop-types'
 import { withRouter } from 'react-router'
+import { HashLink as Link } from 'react-router-hash-link'
 import './style.css'
 import Header from './Header'
 import NavBar from './NavBar'
@@ -19,7 +20,7 @@ export const Page = ({ children, location }) => {
 
   return (
     <React.Fragment>
-      <a className='skipToMain' href='#main'>Skip to main content</a>
+      <Link className='skipToMain' to='#main'>Skip to main content</Link>
       <Header />
       <NavBar />
       <div className={contentClass}>

--- a/src/Components/App/Page/style.css
+++ b/src/Components/App/Page/style.css
@@ -1,7 +1,11 @@
 .mainContent {
-  margin: 0 auto;
+  margin: 0 auto 1.8rem;
   min-height: 90vh;
   width: var(--inner-page-width);
+}
+
+.mainContent.viewer {
+  margin: 0 auto;
 }
 
 @media (max-width: 780px) {

--- a/src/Components/App/Page/style.css
+++ b/src/Components/App/Page/style.css
@@ -2,7 +2,6 @@
   margin: 0 auto;
   min-height: 90vh;
   width: var(--inner-page-width);
-  padding-top: 1.8em;
 }
 
 @media (max-width: 780px) {
@@ -10,4 +9,30 @@
     margin: 0 20px;
     width: calc(100% - 40px);
   }
+}
+
+a.skipToMain {
+    left:-999px;
+    position:absolute;
+    top:auto;
+    width:1px;
+    height:1px;
+    overflow:hidden;
+    z-index:-999;
+}
+a.skipToMain:focus, a.skipToMain:active {
+    color: #fff;
+    background-color:#000;
+    left: auto;
+    top: auto;
+    width: 30%;
+    height: auto;
+    overflow:auto;
+    margin: 10px 35%;
+    padding:5px;
+    border-radius: 15px;
+    border:4px solid yellow;
+    text-align:center;
+    font-size:1.2em;
+    z-index:999;
 }

--- a/src/Components/App/Page/test.js
+++ b/src/Components/App/Page/test.js
@@ -1,9 +1,17 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { Page } from './'
+import { Page, getClass } from './'
 import Header from './Header'
 import NavBar from './NavBar'
 import Footer from './Footer'
+import {
+  BROWSE_CONTEXT,
+  COLLECTION_CONTEXT,
+  ITEM_CONTEXT,
+  VIEWER_CONTEXT,
+  EXHIBITIONS_CONTEXT,
+  SEARCH_CONTEXT,
+} from 'Constants/viewingContexts'
 
 const location = {
   pathname: '/',
@@ -17,4 +25,39 @@ test('Page renders Header, NavBar, Footer and specified child content', () => {
   expect(wrapper.find('.mainContent').exists()).toBeTruthy()
   expect(wrapper.find('.childContent').exists()).toBeTruthy()
   expect(wrapper.find('.childContent').text()).toEqual('Some Content')
+})
+
+describe('test getClass', () => {
+  test('/', () => {
+    const result = getClass('/')
+    expect(result).toEqual('home mainContent')
+  })
+  test('BROWSE_CONTEXT', () => {
+    const result = getClass(`/${BROWSE_CONTEXT}`)
+    expect(result).toEqual('browse mainContent')
+  })
+  test('COLLECTION_CONTEXT', () => {
+    const result = getClass(`/${COLLECTION_CONTEXT}`)
+    expect(result).toEqual('collection mainContent')
+  })
+  test('ITEM_CONTEXT', () => {
+    const result = getClass(`/${ITEM_CONTEXT}`)
+    expect(result).toEqual('item mainContent')
+  })
+  test('VIEWER_CONTEXT', () => {
+    const result = getClass(`/${VIEWER_CONTEXT}`)
+    expect(result).toEqual('viewer mainContent')
+  })
+  test('EXHIBITIONS_CONTEXT', () => {
+    const result = getClass(`/${EXHIBITIONS_CONTEXT}`)
+    expect(result).toEqual('exhibitions mainContent')
+  })
+  test('SEARCH_CONTEXT', () => {
+    const result = getClass(`/${SEARCH_CONTEXT}`)
+    expect(result).toEqual('search mainContent')
+  })
+  test('/something/else', () => {
+    const result = getClass('/something/else')
+    expect(result).toEqual('mainContent')
+  })
 })

--- a/src/Components/Exhibitions/index.js
+++ b/src/Components/Exhibitions/index.js
@@ -5,15 +5,17 @@ import ManifestCardList from 'Components/Shared/ManifestCardList'
 
 const Exhibitions = () => {
   return (
-    <React.Fragment>
-      <h2>Exhibits</h2>
-      <div className='exhibitionCardList'>
-        <ManifestCardList
-          items={items}
-          className='exhibitionCard'
-        />
-      </div>
-    </React.Fragment>
+    <main id='main'>
+      <article>
+        <h1 className='staticTitle'>Exhibits</h1>
+        <div className='exhibitionCardList'>
+          <ManifestCardList
+            items={items}
+            className='exhibitionCard'
+          />
+        </div>
+      </article>
+    </main>
   )
 }
 

--- a/src/Components/Home/HomeBanner/index.js
+++ b/src/Components/Home/HomeBanner/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import SearchBox from 'Components/Shared/SearchBox'
 import bannerImage from 'Static/images/banner.jpg'
 
 const HomeBanner = () => {
@@ -12,6 +13,7 @@ const HomeBanner = () => {
       <div className='imageCaption'>
         <div className='captionFrame'>
           <h1>Explore digitized artwork, rare books, artifacts, and archival materials from the University of Notre Dame.</h1>
+          <SearchBox />
         </div>
       </div>
       <div className='imageCitation'>

--- a/src/Components/Home/HomeCardGroups/HomeCardGroup/index.js
+++ b/src/Components/Home/HomeCardGroups/HomeCardGroup/index.js
@@ -5,13 +5,13 @@ import CardLink from 'Components/Shared/CardLink'
 
 const HomeCardGroup = ({ label, items }) => {
   return (
-    <div className='featured'>
+    <article className='featured'>
       <h2>{label}</h2>
       <div className='grid-x grid-margin-x'>
         {
           items.map((item, index) => {
             return (
-              <div className='cell large-4' key={index}>
+              <section className='cell large-4' key={index}>
                 <CardLink url={item.target || '/'} >
                   <figure>
                     <IIIFImage
@@ -21,13 +21,13 @@ const HomeCardGroup = ({ label, items }) => {
                     <figcaption>{item.label}</figcaption>
                   </figure>
                 </CardLink>
-              </div>
+              </section>
 
             )
           })
         }
       </div>
-    </div>
+    </article>
   )
 }
 

--- a/src/Components/Home/index.js
+++ b/src/Components/Home/index.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import SearchBox from 'Components/Shared/SearchBox'
 import HomeBanner from './HomeBanner'
 import HomeCardGroups from './HomeCardGroups'
 import image1 from 'Static/images/01.jpg'
@@ -31,9 +30,12 @@ const groups = [
 const Home = () => {
   return (
     <React.Fragment>
-      <SearchBox />
       <HomeBanner />
-      <HomeCardGroups groups={groups} />
+      <main id='main'>
+        <article>
+          <HomeCardGroups groups={groups} />
+        </article>
+      </main>
     </React.Fragment>
   )
 }

--- a/src/Components/Home/style.css
+++ b/src/Components/Home/style.css
@@ -1,4 +1,4 @@
-.home.mainContent {
+main.home {
   position: relative;
 	margin-top: 0;
   margin-bottom: 1rem;
@@ -8,10 +8,10 @@
 .banner {
 	position: relative;
 	height: 363px;
+  overflow: hidden;
 }
 
 .bannerImage {
-	width: 100%;
 	position: absolute;
 	top: 0;
 	left: 0;
@@ -22,7 +22,7 @@
 	top: 50px;
 	left: 0;
 	width: 724px;
-	padding: 12px 12px 115px 12px;
+	padding: 12px 12px 12px 12px;
 	background: rgba(0, 0, 0, 0.6);
 	z-index: 5;
 	margin: 0 auto;
@@ -86,13 +86,7 @@ p.citation sub {
 }
 
 .home .searchComponent {
-	position: absolute;
-	top: 165px;
 	z-index: 9;
-	left: 280px;
-}
-
-.home .searchComponent {
 	width: 700px;
 }
 
@@ -131,4 +125,8 @@ p.citation sub {
 	font-weight: bold;
 	color: #fff;
 	text-shadow: 0px 0px 12px rgba(0, 0, 0, 0.65);
+}
+
+h1.accessibilityOnly {
+  display: none;
 }

--- a/src/Components/Layouts/ContentLeftSidebar/MainSide/index.js
+++ b/src/Components/Layouts/ContentLeftSidebar/MainSide/index.js
@@ -2,7 +2,9 @@ import React from 'react'
 import { PropTypes } from 'prop-types'
 const MainSide = ({ children }) => {
   return (
-    <div className='mainSide'>{children}</div>
+    <main id='main' className='mainSide'>
+      <article>{children}</article>
+    </main>
   )
 }
 

--- a/src/Components/Layouts/ContentLeftSidebar/Sidebar/index.js
+++ b/src/Components/Layouts/ContentLeftSidebar/Sidebar/index.js
@@ -3,10 +3,10 @@ import { PropTypes } from 'prop-types'
 
 const Sidebar = ({ title, children }) => {
   return (
-    <div className='sideBar'>
+    <aside className='sideBar'>
       { title ? <h2>{title}</h2> : null }
       {children}
-    </div>
+    </aside>
   )
 }
 Sidebar.propTypes = {

--- a/src/Components/Layouts/ContentLeftSidebar/Sidebar/test.js
+++ b/src/Components/Layouts/ContentLeftSidebar/Sidebar/test.js
@@ -4,13 +4,13 @@ import Sidebar from './'
 
 test('Sidebar without a title does not render a title', () => {
   const wrapper = mount(<Sidebar children={null} />)
-  expect(wrapper.find('div').exists()).toBeTruthy()
+  expect(wrapper.find('aside').exists()).toBeTruthy()
   expect(wrapper.find('h2').exists()).toBeFalsy()
 })
 
 test('Sidebar with title renders a title', () => {
   const wrapper = mount(<Sidebar title='TEST TITLE' children={null} />)
-  expect(wrapper.find('div').exists()).toBeTruthy()
+  expect(wrapper.find('aside').exists()).toBeTruthy()
   expect(wrapper.find('h2').exists()).toBeTruthy()
   expect(wrapper.find('h2').text()).toEqual('TEST TITLE')
 })

--- a/src/Components/ManifestView/Breadcrumb/style.css
+++ b/src/Components/ManifestView/Breadcrumb/style.css
@@ -1,3 +1,8 @@
+nav.breadcrumbs {
+  font-size: .8rem;
+  padding-bottom: 1rem;
+  padding-top: 1.8rem;
+}
 nav.breadcrumbs a {
   text-decoration: none;
 }

--- a/src/Components/ManifestView/Browse/index.js
+++ b/src/Components/ManifestView/Browse/index.js
@@ -12,12 +12,14 @@ const Browse = ({ currentManifest }) => {
   return (
     <React.Fragment>
       <Breadcrumb />
-      <h1>Browse All Collections</h1>
-      <FilterTabBar />
-      <ManifestCardList
-        items={items}
-        className='browseCard'
-      />
+      <main id='main'>
+        <h1>Browse All Collections</h1>
+        <FilterTabBar />
+        <ManifestCardList
+          items={items}
+          className='browseCard'
+        />
+      </main>
     </React.Fragment>
   )
 }

--- a/src/Components/ManifestView/Collection/index.js
+++ b/src/Components/ManifestView/Collection/index.js
@@ -19,8 +19,9 @@ export const Collection = ({ currentManifest, manifestReducer }) => {
         altText={currentManifest.data.label}
       />
       <Breadcrumb />
+      <h1>{currentManifest.data.label}</h1>
       <ContentLeftSidebar
-        sidebarTitle={currentManifest.data.label}
+
         sidebarContent={sidebar}>
 
         <DisplayViewClass reducer={manifestReducer}>

--- a/src/Components/ManifestView/Item/ItemActionButtons/index.js
+++ b/src/Components/ManifestView/Item/ItemActionButtons/index.js
@@ -10,7 +10,7 @@ import './style.css'
 
 const ItemActionButtons = () => {
   return (
-    <div className='actionButtons'>
+    <section className='actionButtons'>
       <ActionButton
         name='download'
         action={printAction}
@@ -33,7 +33,7 @@ const ItemActionButtons = () => {
         activeIcon={bookmarkActive}
         isActive
       />
-    </div>
+    </section>
   )
 }
 

--- a/src/Components/ManifestView/Item/ItemSide/index.js
+++ b/src/Components/ManifestView/Item/ItemSide/index.js
@@ -5,10 +5,10 @@ import ItemAlternateViews from './ItemAlternateViews'
 
 const ItemSide = ({ currentManifest }) => {
   return (
-    <React.Fragment>
+    <section>
       <ItemMainImage currentManifest={currentManifest} />
       <ItemAlternateViews currentManifest={currentManifest} />
-    </React.Fragment>
+    </section>
   )
 }
 

--- a/src/Components/ManifestView/Viewer/index.js
+++ b/src/Components/ManifestView/Viewer/index.js
@@ -14,13 +14,16 @@ export const Viewer = ({ currentManifest, history }) => {
     viewerParams = `&cv=${values.cv || 0}`
   }
   return (
-    <iframe
-      allowFullScreen
-      id='universalViewer'
-      title='universal-viewer'
-      sandbox='allow-same-origin allow-scripts allow-pointer-lock allow-popups'
-      src={`${UNIVERSAL_VIEWER_BASE_URL}#?manifest=${typy(currentManifest, 'data[@id]').safeString}${viewerParams}`}
-    />
+    <main id='main'>
+      <h1 className='accessibilityOnly'>{typy(currentManifest, 'data.label').safeString}</h1>
+      <iframe
+        allowFullScreen
+        id='universalViewer'
+        title='universal-viewer'
+        sandbox='allow-same-origin allow-scripts allow-pointer-lock allow-popups'
+        src={`${UNIVERSAL_VIEWER_BASE_URL}#?manifest=${typy(currentManifest, 'data[@id]').safeString}${viewerParams}`}
+      />
+    </main>
   )
 }
 

--- a/src/Components/Search/SearchDisplay/index.js
+++ b/src/Components/Search/SearchDisplay/index.js
@@ -15,6 +15,7 @@ export const SearchDisplay = ({ location, searchReducer }) => {
   if (location.search) {
     return (
       <React.Fragment>
+        <h1 className='staticTitle'>Search Results</h1>
         <SearchBox />
         <ContentLeftSidebar
           sidebarContent={<Facets />}

--- a/src/Components/Shared/Card/index.js
+++ b/src/Components/Shared/Card/index.js
@@ -14,17 +14,19 @@ export const Card = ({ title, image, url, className, children, match }) => {
         url={urlContext(url, match)}
         displayClass={displayClass}
       >
-        <IIIFImage
-          image={image}
-          alt={title}
-          previewBlur
-        />
-        <div>
-          <h3>{title}</h3>
-          <div className='additional'>
-            {children}
+        <article>
+          <IIIFImage
+            image={image}
+            alt={title}
+            previewBlur
+          />
+          <div>
+            <h3>{title}</h3>
+            <div className='additional'>
+              {children}
+            </div>
           </div>
-        </div>
+        </article>
       </CardLink>
     )
   }

--- a/src/Components/Shared/LinkList/index.js
+++ b/src/Components/Shared/LinkList/index.js
@@ -5,7 +5,7 @@ import { HashLink as Link } from 'react-router-hash-link'
 const LinkList = ({ items }) => {
   if (items) {
     return (
-      <React.Fragment>
+      <nav>
         {
           items.map(item => {
             return (
@@ -16,7 +16,7 @@ const LinkList = ({ items }) => {
             )
           })
         }
-      </React.Fragment>
+      </nav>
     )
   }
   return null

--- a/src/Components/Shared/ManifestCardList/index.js
+++ b/src/Components/Shared/ManifestCardList/index.js
@@ -12,7 +12,7 @@ const ManifestCardList = ({ items, start, perPage, className }) => {
   // make sure we have items and we're not trying to start after the array end
   if (items && start < items.length) {
     return (
-      <div className='cardList'>
+      <section className='cardList'>
         {
           itemsForDisplay(items, start, perPage).map(item => {
             return (
@@ -28,7 +28,7 @@ const ManifestCardList = ({ items, start, perPage, className }) => {
             )
           })
         }
-      </div>
+      </section>
     )
   }
   return <NotFound />

--- a/src/Components/Shared/NotFound/index.js
+++ b/src/Components/Shared/NotFound/index.js
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types'
 
 const NotFound = ({ title, message }) => {
   return (
-    <React.Fragment>
+    <article>
       <h1>{title || 'Not Found'}</h1>
       <div>{message || 'The page you requested could not be found.'}</div>
-    </React.Fragment>
+    </article>
   )
 }
 

--- a/src/Components/Shared/SearchBox/index.js
+++ b/src/Components/Shared/SearchBox/index.js
@@ -8,7 +8,7 @@ import imgHelp from './help.svg'
 
 const SearchBox = () => {
   return (
-    <div className='searchComponent' >
+    <section className='searchComponent' >
       <div className='searchBox'>
         <SearchButton submitSearch={submitSearch} />
         <SearchField submitSearch={submitSearch} />
@@ -17,7 +17,7 @@ const SearchBox = () => {
       <div className='advancedSearch'>
         <Link to='/advancedsearch'>Advanced Search</Link>
       </div>
-    </div>
+    </section>
   )
 }
 

--- a/src/Components/StaticPage/About/index.js
+++ b/src/Components/StaticPage/About/index.js
@@ -9,7 +9,7 @@ const About = () => {
   return (
     <React.Fragment>
       <div id='introduction' />
-      <h2>Introduction</h2>
+      <h1 className='staticTitle'>Introduction</h1>
       <ReactMarkdown source={introduction} />
       <div id='partners' />
       <h2>Project Partners</h2>

--- a/src/Components/StaticPage/About/test.js
+++ b/src/Components/StaticPage/About/test.js
@@ -7,8 +7,8 @@ const wrapper = mount(<About />)
 
 test('About renders introduction section stuff', () => {
   expect(wrapper.find('#introduction').exists()).toBeTruthy()
-  expect(wrapper.find('h2').exists()).toBeTruthy()
-  expect(wrapper.find('h2').first().text()).toEqual('Introduction')
+  expect(wrapper.find('h1').exists()).toBeTruthy()
+  expect(wrapper.find('h1').first().text()).toEqual('Introduction')
   expect(wrapper.find(ReactMarkdown).first().props().source).toEqual('introduction.md')
 })
 

--- a/src/Components/StaticPage/Learn/index.js
+++ b/src/Components/StaticPage/Learn/index.js
@@ -6,7 +6,7 @@ const Learn = () => {
   return (
     <React.Fragment>
       <div id='learn' />
-      <h1 className='staticTitle'>Learn</h1>
+      <h2 className='staticTitle'>Learn</h2>
       <article>
         <ReactMarkdown source={learn} />
       </article>

--- a/src/Components/StaticPage/Learn/index.js
+++ b/src/Components/StaticPage/Learn/index.js
@@ -6,8 +6,10 @@ const Learn = () => {
   return (
     <React.Fragment>
       <div id='learn' />
-      <h2>Learn</h2>
-      <ReactMarkdown source={learn} />
+      <h1 className='staticTitle'>Learn</h1>
+      <article>
+        <ReactMarkdown source={learn} />
+      </article>
     </React.Fragment>
   )
 }

--- a/src/Components/StaticPage/index.js
+++ b/src/Components/StaticPage/index.js
@@ -20,6 +20,8 @@ export const StaticPage = ({ match }) => {
   let content
   switch (pageType) {
     case ABOUT_CONTEXT:
+      title = 'About'
+      // topics = require('Configurations/About').topics
       content = <About />
       break
     case HELP_CONTEXT:
@@ -29,7 +31,7 @@ export const StaticPage = ({ match }) => {
       break
     case LEARN_CONTEXT:
       title = 'Learn'
-      topics = require('Configurations/Learn').topics
+      // topics = require('Configurations/Learn').topics
       content = <Learn />
       break
     default:
@@ -38,18 +40,22 @@ export const StaticPage = ({ match }) => {
   }
   if (topics.length > 0) {
     return (
-      <ContentLeftSidebar
-        sidebarTitle={title}
-        sidebarContent={<LinkList items={topics} />}
-      >
-        {content}
-      </ContentLeftSidebar>
+      <article>
+        <h1 className='staticTitle'>{title}</h1>
+        <ContentLeftSidebar
+          sidebarContent={<LinkList items={topics} />}
+        >
+          {content}
+        </ContentLeftSidebar>
+      </article>
     )
   }
   return (
-    <React.Fragment>
-      { content }
-    </React.Fragment>
+    <main id='main'>
+      <article>
+        { content }
+      </article>
+    </main>
   )
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -32,7 +32,9 @@ p {
 h1, h2, h3, h4, h5, h6, p {
   margin-top: 0;
 }
-
+h1.staticTitle {
+  padding-top: 1.8rem;
+}
 h2 {
   font-size: 32px;
   margin-bottom: .8em;


### PR DESCRIPTION
* MEL-291 - Add semantic tags `main`, `aside`, `article`, `section`, `nav`, `header`, `footer`, etc.
* MEL-292 - Make sure all pages have an `h1`
* MEL-308 - Fix gap css
* Add additional global classes on mainContent that can be use for specific page type styling.
* Add 'Skip to main' link.